### PR TITLE
Copies Over the GPG Keys Into the Profile Directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,23 @@ backup_profiles: []           # Setup backup profiles
 backup_gpg_key: disabled
 backup_gpg_pw: ""
 backup_gpg_opts: ''
+# within profiles, you can add gpg_public_key_src and gpg_private_key_src with the paths to files
+# with the public and private key files to import them into the profile's directory. This is required
+# for the backup test task to run (when GPG keys are used)
+backup_profiles:
+  - name: "backup-profile-0"
+    schedule: 0 1 * * *
+    source: "postgresql://test-database"
+    target: "file:///backups/test-database"
+    max_age: "1M"
+    full_max_age: "1W"
+    max_full_backups: 4
+    user: "postgres"
+    gpg_key: "DDEF2FE"
+    gpg_pw: "somepassword"
+    gpg_opts: "--pinentry-mode loopback"
+    gpg_private_key_src: "files/priv-key.asc"
+    gpg_public_key_src: "files/pub-key.asc"
 
 # TARGET
 # syntax is

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -53,6 +53,22 @@
 - name: backup-configure | Configure logrotate
   template: src=logrotate.j2 dest=/etc/logrotate.d/backup owner=root group=root mode=0644
 
+- name: backup-configure | Copy the GPG public key into the profile
+  become: true
+  become_user: "{{item.user|default(backup_user)}}"
+  copy: dest={{backup_home}}/{{item.name}}/gpgkey.{{item.gpg_key}}.pub.asc src={{item.gpg_public_key_src}} mode=0700
+  become_user: "{{item.user|default(backup_user)}}"
+  with_items: "{{backup_profiles}}"
+  when: item.gpg_public_key_src is defined
+
+- name: backup-configure | Copy the GPG private key into the profile
+  become: true
+  become_user: "{{item.user|default(backup_user)}}"
+  copy: dest={{backup_home}}/{{item.name}}/gpgkey.{{item.gpg_key}}.sec.asc src={{item.gpg_private_key_src}} mode=0700
+  become_user: "{{item.user|default(backup_user)}}"
+  with_items: "{{backup_profiles}}"
+  when: item.gpg_private_key_src is defined
+
 - name: backup-configure | test backup
   become: true
   become_user: "{{item.user|default(backup_user)}}"


### PR DESCRIPTION
Copies over the GPG public and private key (if provided) into the database
profile's directory on the deployed host. Do this to avoid duply from
attempting to ask for the GPG passphrase when the test backup task is
run.

Signed-off-by: Jason Rogena <jason@rogena.me>