### PR TITLE
Allow Email Notifications as pre and post Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,34 @@ backup_profiles: []           # Setup backup profiles
 # =======================================================
 # (every value can be replaced in jobs individually)
 
+# In each of your backup profiles, you can define pre backup and post backup actions to
+# be executed. Do this by declaring a pre_actions and post_actions lists.
+#
+# The following are supported action types:
+#   command: Run a shell command
+#   email: Send an email
+# 
+# Sample pre_action or post_actions list
+# post_actions:
+#   - type: command
+#     command: "echo 'Backup failed'"
+#   - type: email
+#     name: ona
+#     to: "info@ona.io"
+#     from: "server1@ona.io"
+#     smtp:
+#       port:
+#       host:
+#       user:
+#       password:
+#       use_startls: true
+#     on_error:
+#       subject: ""
+#       message: ""
+#     on_success:
+#       subject: ""
+#       message: ""
+
 # GPG
 backup_gpg_key: disabled
 backup_gpg_pw: ""

--- a/README.md
+++ b/README.md
@@ -70,7 +70,8 @@ backup_profiles: []           # Setup backup profiles
 # Sample pre_action or post_actions list
 # post_actions:
 #   - type: command
-#     command: "echo 'Backup failed'"
+#     on_error:
+#       command: "echo 'Backup failed'"
 #   - type: email
 #     name: ona
 #     to: "info@ona.io"

--- a/tasks/configure-hook-actions.yml
+++ b/tasks/configure-hook-actions.yml
@@ -1,0 +1,18 @@
+---
+- block:
+    - name: backup-configure | Copy the email hook configuration
+      template:
+        src: "email-notification.conf.j2"
+        dest: "{{backup_home}}/{{_backup_profile_name}}/email-notification-{{_backup_action_type}}-{{_backup_hook_action.name}}.conf"
+        owner: "{{_backup_profile_user}}"
+        group: "{{_backup_profile_group}}"
+        mode: 0600
+
+    - name: backup-configure | Copy the email hook script
+      template:
+        src: "email-notification.j2"
+        dest: "{{backup_home}}/{{_backup_profile_name}}/email-notification-{{_backup_action_type}}-{{_backup_hook_action.name}}"
+        owner: "{{_backup_profile_user}}"
+        group: "{{_backup_profile_group}}"
+        mode: 0700
+  when: _backup_hook_action.type == "email"

--- a/tasks/configure-hooks.yml
+++ b/tasks/configure-hooks.yml
@@ -1,0 +1,29 @@
+---
+- set_fact:
+    _backup_profile_name: "{{item.name}}"
+    _backup_profile_user: "{{item.user|default(backup_user)}}"
+    _backup_profile_group: "{{item.group|default(backup_group)}}"
+    _backup_action_type: "pre"
+
+- name: backup-configure | Configure pre scripts
+  template: src=pre.j2 dest={{backup_home}}/{{item.name}}/pre owner={{item.user|default(backup_user)}} group={{item.group|default(backup_group)}} 
+
+- name: backup-configure | Configure profile pre actions
+  include_tasks: configure-hook-actions.yml
+  with_items: "{{item.pre_actions}}"
+  when: item.pre_actions is defined
+  loop_control:
+    loop_var: "_backup_hook_action"
+
+- set_fact:
+    _backup_action_type: "post"
+
+- name: backup-configure | Configure post scripts
+  template: src=post.j2 dest={{backup_home}}/{{item.name}}/post owner={{item.user|default(backup_user)}} group={{item.group|default(backup_group)}}
+
+- name: backup-configure | Configure profile post actions
+  include_tasks: configure-hook-actions.yml
+  with_items: "{{item.post_actions}}"
+  when: item.post_actions is defined
+  loop_control:
+    loop_var: "_backup_hook_action"

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -25,12 +25,8 @@
   template: src=exclude.j2 dest={{backup_home}}/{{item.name}}/exclude owner={{item.user|default(backup_user)}} group={{item.group|default(backup_group)}} 
   with_items: "{{backup_profiles}}"
 
-- name: backup-configure | Configure pre scripts
-  template: src=pre.j2 dest={{backup_home}}/{{item.name}}/pre owner={{item.user|default(backup_user)}} group={{item.group|default(backup_group)}} 
-  with_items: "{{backup_profiles}}"
-
-- name: backup-configure | Configure post scripts
-  template: src=post.j2 dest={{backup_home}}/{{item.name}}/post owner={{item.user|default(backup_user)}} group={{item.group|default(backup_group)}} 
+- name: backup-configure | Configure pre and post hooks
+  include_tasks: configure-hooks.yml
   with_items: "{{backup_profiles}}"
 
 - name: backup-configure | Configure restore scripts

--- a/tasks/install.deb.yml
+++ b/tasks/install.deb.yml
@@ -9,6 +9,7 @@
   - gzip
   - python-boto
   - s3cmd
+  - ssmtp
 
 - set_fact: backup_duplicity_pkg="{{backup_duplicity_pkg}}={{backup_duplicity_version}}"
   when: backup_duplicity_version

--- a/tasks/install.red.yml
+++ b/tasks/install.red.yml
@@ -20,6 +20,7 @@
     - gzip
     - python-boto
     - s3cmd
+    - ssmtp
 
 - set_fact: backup_duplicity_pkg="{{backup_duplicity_pkg}}-{{backup_duplicity_version}}"
   when: backup_duplicity_version

--- a/templates/email-notification.conf.j2
+++ b/templates/email-notification.conf.j2
@@ -1,0 +1,7 @@
+mailhub={{_backup_hook_action.smtp.host}}:{{_backup_hook_action.smtp.port}}
+{% if _backup_hook_action.smtp.use_startls %}
+useSTARTTLS=YES
+{% endif %}
+AuthUser={{_backup_hook_action.smtp.user}}
+AuthPass={{_backup_hook_action.smtp.password}}
+FromLineOverride=YES

--- a/templates/email-notification.j2
+++ b/templates/email-notification.j2
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+#############################################################################
+# This file is responsible for sending email notifications and is intented  #
+# to be fired from either the pre or post hooks.                            #
+#                                                                           #
+# The script relies on the $CMD_ERR environment variable to determine       #
+# whether the previous command (in the case of the post hook this will be   #
+# the backup command and for the pre-hook this will be defaulted to 0 to    #
+# assume success).                                                          #
+#############################################################################
+
+TO="{{_backup_hook_action.to}}"
+FROM="{{_backup_hook_action.from}}"
+EMAIL_PREV_CMD_ERR=${CMD_ERR:-0}
+
+{% if _backup_hook_action.on_success is defined %}
+if [ "$EMAIL_PREV_CMD_ERR" -eq "0" ]; then
+SUBJECT="{{_backup_hook_action.on_success.subject}}"
+MESSAGE="To: ${TO}
+From: ${FROM}
+Subject: ${SUBJECT}
+{{_backup_hook_action.on_success.message}}"
+
+echo "$MESSAGE" | ssmtp -C {{backup_home}}/{{_backup_profile_name}}/email-notification-{{_backup_action_type}}-{{_backup_hook_action.name}}.conf -vvv ${TO}
+fi
+{% endif %}
+
+{% if _backup_hook_action.on_error is defined %}
+if [ "$EMAIL_PREV_CMD_ERR" -ne "0" ]; then
+SUBJECT="{{_backup_hook_action.on_error.subject}}"
+MESSAGE="To: ${TO}
+From: ${FROM}
+Subject: ${SUBJECT}
+{{_backup_hook_action.on_error.message}}"
+
+echo "$MESSAGE" | ssmtp -C {{backup_home}}/{{_backup_profile_name}}/email-notification-{{_backup_action_type}}-{{_backup_hook_action.name}}.conf -vvv ${TO}
+fi
+{% endif %}

--- a/templates/post.j2
+++ b/templates/post.j2
@@ -9,6 +9,13 @@ WORKDIR={{backup_work}}/{{item.name}}
 rm -rf $WORKDIR/dump
 {% endif %}
 
-{% for action in item.post_actions|default([]) %}
-{{ action }}
+{% for _backup_hook_action in item.post_actions|default([]) %}
+{% if _backup_hook_action is defined and _backup_hook_action is iterable and _backup_hook_action is not string %}
+{% if _backup_hook_action.type == "command" %}
+{{_backup_hook_action.command}}
+{% endif %}
+{% if _backup_hook_action.type == "email" %}
+{{backup_home}}/{{_backup_profile_name}}/email-notification-post-{{_backup_hook_action.name}}
+{% endif %}
+{% endif %}
 {% endfor %}

--- a/templates/pre.j2
+++ b/templates/pre.j2
@@ -44,7 +44,16 @@ mongodump --out $WORKDIR/dump $ARGS
 {% for _backup_hook_action in item.pre_actions|default([]) %}
 {% if _backup_hook_action is defined and _backup_hook_action is iterable and _backup_hook_action is not string %}
 {% if _backup_hook_action.type == "command" %}
-{{_backup_hook_action.command}}
+{% if _backup_hook_action.on_success is defined and _backup_hook_action.on_success is iterable %}
+if [ "${CMD_ERR:-0}" -eq "0" ]; then
+  {{_backup_hook_action.on_success.command}}
+fi
+{% endif %}
+{% if _backup_hook_action.on_error is defined and _backup_hook_action.on_error is iterable %}
+if [ "${CMD_ERR:-0}" -ne "0" ]; then
+  {{_backup_hook_action.on_error.command}}
+fi
+{% endif %}
 {% endif %}
 {% if _backup_hook_action.type == "email" %}
 {{backup_home}}/{{_backup_profile_name}}/email-notification-pre-{{_backup_hook_action.name}}

--- a/templates/pre.j2
+++ b/templates/pre.j2
@@ -41,6 +41,13 @@ mongodump --out $WORKDIR/dump $ARGS
 
 {% endif %}
 
-{% for action in item.pre_actions|default([]) %}
-{{ action }}
+{% for _backup_hook_action in item.pre_actions|default([]) %}
+{% if _backup_hook_action is defined and _backup_hook_action is iterable and _backup_hook_action is not string %}
+{% if _backup_hook_action.type == "command" %}
+{{_backup_hook_action.command}}
+{% endif %}
+{% if _backup_hook_action.type == "email" %}
+{{backup_home}}/{{_backup_profile_name}}/email-notification-pre-{{_backup_hook_action.name}}
+{% endif %}
+{% endif %}
 {% endfor %}


### PR DESCRIPTION
Allow Duply to send email notifications as either pre or post actions
for email profiles.

Signed-off-by: Jason Rogena <jason@rogena.me>